### PR TITLE
Fix /api/clients endpoint

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientDetailsEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientDetailsEntity.java
@@ -152,7 +152,7 @@ public class ClientDetailsEntity implements ClientDetails {
 	private Date createdAt; // time the client was created
 	private boolean clearAccessTokensOnRefresh = true; // do we clear access tokens on refresh?
 	private Integer deviceCodeValiditySeconds; // timeout for device codes
-	private ClientLastUsedEntity clientLastUsed; // last used info
+	private transient ClientLastUsedEntity clientLastUsed; // last used info
 	private boolean active = true;
 	private Date statusChangedOn;
 	private String statusChangedBy;


### PR DESCRIPTION
#12 introduced a bug on the ``/api/clients`` endpoint as found by @SteDev2 . 
The server is returning error 500: `java.lang.reflect.InaccessibleObjectException: Unable to make field private final int java.time.LocalDate.year accessible: module java.base does not "opens java.time" to unnamed module @642a7222`

This fixes the problem.