### PR TITLE
Make "createRefreshToken" method public

### DIFF
--- a/openid-connect-client/pom.xml
+++ b/openid-connect-client/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<artifactId>openid-connect-parent</artifactId>
 		<groupId>org.mitre</groupId>
-		<version>1.3.6.cnaf-20240414</version>
+		<version>1.3.6.cnaf-20240604</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>openid-connect-client</artifactId>

--- a/openid-connect-common/pom.xml
+++ b/openid-connect-common/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<artifactId>openid-connect-parent</artifactId>
 		<groupId>org.mitre</groupId>
-		<version>1.3.6.cnaf-20240414</version>
+		<version>1.3.6.cnaf-20240604</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>openid-connect-common</artifactId>

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/service/OAuth2TokenEntityService.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/service/OAuth2TokenEntityService.java
@@ -20,6 +20,7 @@ package org.mitre.oauth2.service;
 import java.util.List;
 import java.util.Set;
 
+import org.mitre.oauth2.model.AuthenticationHolderEntity;
 import org.mitre.oauth2.model.ClientDetailsEntity;
 import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
 import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
@@ -28,39 +29,40 @@ import org.springframework.security.oauth2.provider.token.AuthorizationServerTok
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
 
 @SuppressWarnings("deprecation")
-public interface OAuth2TokenEntityService
-    extends AuthorizationServerTokenServices, ResourceServerTokenServices {
+public interface OAuth2TokenEntityService extends AuthorizationServerTokenServices, ResourceServerTokenServices {
 
-  @Override
-  public OAuth2AccessTokenEntity readAccessToken(String accessTokenValue);
+	@Override
+	public OAuth2AccessTokenEntity readAccessToken(String accessTokenValue);
 
-  public OAuth2RefreshTokenEntity getRefreshToken(String refreshTokenValue);
+	public OAuth2RefreshTokenEntity getRefreshToken(String refreshTokenValue);
 
-  public void revokeRefreshToken(OAuth2RefreshTokenEntity refreshToken);
+	public void revokeRefreshToken(OAuth2RefreshTokenEntity refreshToken);
 
-  public void revokeAccessToken(OAuth2AccessTokenEntity accessToken);
+	public void revokeAccessToken(OAuth2AccessTokenEntity accessToken);
 
-  public List<OAuth2AccessTokenEntity> getAccessTokensForClient(ClientDetailsEntity client);
+	public List<OAuth2AccessTokenEntity> getAccessTokensForClient(ClientDetailsEntity client);
 
-  public List<OAuth2RefreshTokenEntity> getRefreshTokensForClient(ClientDetailsEntity client);
+	public List<OAuth2RefreshTokenEntity> getRefreshTokensForClient(ClientDetailsEntity client);
 
-  public void clearExpiredTokens();
+	public void clearExpiredTokens();
 
-  public OAuth2AccessTokenEntity saveAccessToken(OAuth2AccessTokenEntity accessToken);
+	public OAuth2AccessTokenEntity saveAccessToken(OAuth2AccessTokenEntity accessToken);
 
-  public OAuth2RefreshTokenEntity saveRefreshToken(OAuth2RefreshTokenEntity refreshToken);
+	public OAuth2RefreshTokenEntity saveRefreshToken(OAuth2RefreshTokenEntity refreshToken);
 
-  @Override
-  public OAuth2AccessTokenEntity getAccessToken(OAuth2Authentication authentication);
+	@Override
+	public OAuth2AccessTokenEntity getAccessToken(OAuth2Authentication authentication);
 
-  public OAuth2AccessTokenEntity getAccessTokenById(Long id);
+	public OAuth2AccessTokenEntity getAccessTokenById(Long id);
 
-  public OAuth2RefreshTokenEntity getRefreshTokenById(Long id);
+	public OAuth2RefreshTokenEntity getRefreshTokenById(Long id);
 
-  public Set<OAuth2AccessTokenEntity> getAllAccessTokensForUser(String name);
+	public Set<OAuth2AccessTokenEntity> getAllAccessTokensForUser(String name);
 
-  public Set<OAuth2RefreshTokenEntity> getAllRefreshTokensForUser(String name);
+	public Set<OAuth2RefreshTokenEntity> getAllRefreshTokensForUser(String name);
 
-  public OAuth2AccessTokenEntity getRegistrationAccessTokenForClient(ClientDetailsEntity client);
+	public OAuth2AccessTokenEntity getRegistrationAccessTokenForClient(ClientDetailsEntity client);
+
+	public OAuth2RefreshTokenEntity createRefreshToken(ClientDetailsEntity client, AuthenticationHolderEntity authHolder);
 
 }

--- a/openid-connect-server/pom.xml
+++ b/openid-connect-server/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.mitre</groupId>
 		<artifactId>openid-connect-parent</artifactId>
-		<version>1.3.6.cnaf-20240414</version>
+		<version>1.3.6.cnaf-20240604</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<build>

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
@@ -278,7 +278,7 @@ public class DefaultOAuth2ProviderTokenService implements OAuth2TokenEntityServi
   }
 
 
-  private OAuth2RefreshTokenEntity createRefreshToken(ClientDetailsEntity client,
+  public OAuth2RefreshTokenEntity createRefreshToken(ClientDetailsEntity client,
       AuthenticationHolderEntity authHolder) {
     OAuth2RefreshTokenEntity refreshToken = new OAuth2RefreshTokenEntity(); // refreshTokenFactory.createNewRefreshToken();
     JWTClaimsSet.Builder refreshClaims = new JWTClaimsSet.Builder();

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.mitre</groupId>
 	<artifactId>openid-connect-parent</artifactId>
-	<version>1.3.6.cnaf-20240414</version>
+	<version>1.3.6.cnaf-20240604</version>
 	<name>MITREid Connect</name>
 	<packaging>pom</packaging>
 	<parent>


### PR DESCRIPTION
In particular, I would like to save an AUDIT event on IAM when the refresh token is created, as it is already in place for the AT creation.