### PR TITLE
Add client type column to client relying party table

### DIFF
--- a/openid-connect-client/pom.xml
+++ b/openid-connect-client/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<artifactId>openid-connect-parent</artifactId>
 		<groupId>org.mitre</groupId>
-		<version>1.3.7.cnaf-20260213</version>
+		<version>1.3.7.cnaf-20260317</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>openid-connect-client</artifactId>

--- a/openid-connect-common/pom.xml
+++ b/openid-connect-common/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<artifactId>openid-connect-parent</artifactId>
 		<groupId>org.mitre</groupId>
-		<version>1.3.7.cnaf-20260213</version>
+		<version>1.3.7.cnaf-20260317</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>openid-connect-common</artifactId>

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientDetailsEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientDetailsEntity.java
@@ -157,7 +157,7 @@ public class ClientDetailsEntity implements ClientDetails {
   private Integer deviceCodeValiditySeconds; // timeout for device codes
   private transient ClientLastUsedEntity clientLastUsed; // last used info
   private transient ClientRelyingPartyEntity clientRelyingParty; // relying party info (entity_id,
-                                                                 // expiration)
+                                                                 // expiration, client_type)
   private boolean active = true;
   private Date statusChangedOn;
   private String statusChangedBy;

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientRelyingPartyEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientRelyingPartyEntity.java
@@ -20,6 +20,8 @@ import java.util.Date;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapsId;
@@ -29,6 +31,10 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "client_relying_party")
 public class ClientRelyingPartyEntity {
+
+  public enum ClientType {
+    INTERNAL, EXTERNAL
+  }
 
   @Id
   @Column(name = "client_details_id")
@@ -45,14 +51,20 @@ public class ClientRelyingPartyEntity {
   @Column(name = "entity_id", nullable = false)
   private String entityId;
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "client_type", nullable = false)
+  private ClientType clientType;
+
   public ClientRelyingPartyEntity() {
     // empty constructor
   }
 
-  public ClientRelyingPartyEntity(ClientDetailsEntity client, Date expiration, String entityId) {
+  public ClientRelyingPartyEntity(ClientDetailsEntity client, Date expiration, String entityId,
+      ClientType clientType) {
     this.client = client;
     this.expiration = expiration;
     this.entityId = entityId;
+    this.clientType = clientType;
   }
 
   public Long getId() {
@@ -85,5 +97,13 @@ public class ClientRelyingPartyEntity {
 
   public void setEntityId(String entityId) {
     this.entityId = entityId;
+  }
+
+  public ClientType getClientType() {
+    return clientType;
+  }
+
+  public void setClientType(ClientType clientType) {
+    this.clientType = clientType;
   }
 }

--- a/openid-connect-server/pom.xml
+++ b/openid-connect-server/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.mitre</groupId>
 		<artifactId>openid-connect-parent</artifactId>
-		<version>1.3.7.cnaf-20260213</version>
+		<version>1.3.7.cnaf-20260317</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.mitre</groupId>
 	<artifactId>openid-connect-parent</artifactId>
-	<version>1.3.7.cnaf-20260213</version>
+	<version>1.3.7.cnaf-20260317</version>
 	<name>MITREid Connect</name>
 	<packaging>pom</packaging>
 	<parent>


### PR DESCRIPTION
Within the OpenID federation framework, this column can be useful to distinguish between clients created internally by the IAM (OP role) and clients registered by external OPs and stored in the IAM (RP role) database.